### PR TITLE
Correct typos in variable names

### DIFF
--- a/OpenStack/terraform/hcl/single-vm-deploy/main.tf
+++ b/OpenStack/terraform/hcl/single-vm-deploy/main.tf
@@ -39,7 +39,7 @@ provider "openstack" {
 
 variable "number_of_instances" {}
 
-resource "openstack_compute_instance_v2" "sinlge-vm" {
+resource "openstack_compute_instance_v2" "single-vm" {
   count     = "${var.number_of_instances}"
   name      = "${format("terraform-single-vm-%02d", count.index+1)}"
   image_id  = "${var.openstack_image_id}"
@@ -57,6 +57,6 @@ resource "openstack_compute_instance_v2" "sinlge-vm" {
   }
 }
 
-output "sinlge-vm-ip" {
+output "single-vm-ip" {
   value = "${openstack_compute_instance_v2.single-vm.*.network.0.fixed_ip_v4}"
 }


### PR DESCRIPTION
Fixed the 2 instances of "sinlge" in the terraform variable names. 